### PR TITLE
feat: Added Stripe Restricted API keys support

### DIFF
--- a/lib/Pattern.js
+++ b/lib/Pattern.js
@@ -33,7 +33,7 @@ module.exports = [
   // ========================
   {
     name: 'STRIPE_API_KEY',
-    regex: /sk_(test|live)_[a-zA-Z0-9]{24,}/g,
+    regex: /(sk|rk)_(test|live)_[a-zA-Z0-9]{24,}/g,
   },
   {
     name: 'SENDGRID_API_KEY',

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -63,7 +63,7 @@ function analyzeEntropy(value, options = {}) {
 function validateSecretFormat(value, secretType) {
   const formatValidators = {
     'STRIPE_API_KEY': {
-      pattern: /^sk_(test|live)_[a-zA-Z0-9]{24,}$/,
+      pattern: /^(sk|rk)_(test|live)_[a-zA-Z0-9]{24,}$/,
       description: 'Stripe API key format: sk_(test|live)_...'
     },
     'SENDGRID_API_KEY': {


### PR DESCRIPTION
Current implementation only supported standard stripe API keys (starting with sk_...). Stripe also provides **Restricted keys** (rk_...) alongside their standard keys and publishable keys. [Stripe docs reference](https://docs.stripe.com/keys)