### PR TITLE
feat: Added Groq API key detection

### DIFF
--- a/lib/Pattern.js
+++ b/lib/Pattern.js
@@ -60,6 +60,10 @@ module.exports = [
     name: 'COHERE_API_KEY',
     regex: /cohere_[a-zA-Z0-9-_]{32,}/g,
   },
+  {
+    name: 'GROQ_API_KEY',
+    regex: /gsk_[a-zA-Z0-9]{52,}/g,
+  },
 
   // ========================
   // ☁️ CLOUD CREDENTIALS

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -82,6 +82,10 @@ function validateSecretFormat(value, secretType) {
       pattern: /^hf_[a-zA-Z0-9]{32,}$/,
       description: 'Hugging Face token format: hf_...'
     },
+    'GROQ_API_KEY': {
+      pattern: /^gsk_[a-zA-Z0-9]{52,}$/,
+      description: 'GROQ API key format: gsk_...'
+    },
     'AWS_ACCESS_KEY_ID': {
       pattern: /^AKIA[0-9A-Z]{16}$/,
       description: 'AWS Access Key ID format: AKIA...'


### PR DESCRIPTION
Adding groq [https://groq.com/](https://groq.com/) API key validation.

Groq API key (generated myself but obfuscated)
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
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

All keys start with `gsk_` and have 52 alphanumeric characters. `WGdyb3FY` seems to be repeating in the middle, but that could be userid of some sort