### PR TITLE
feat: Added Openrouter API key detection

### DIFF
--- a/lib/Pattern.js
+++ b/lib/Pattern.js
@@ -57,6 +57,10 @@ module.exports = [
     regex: /hf_[a-zA-Z0-9]{32,}/g,
   },
   {
+    name: 'OPENROUTER_API_KEY',
+    regex: /sk-or-v1-[a-f0-9]{64,}/g,
+  },
+  {
     name: 'COHERE_API_KEY',
     regex: /cohere_[a-zA-Z0-9-_]{32,}/g,
   },

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -78,6 +78,10 @@ function validateSecretFormat(value, secretType) {
       pattern: /^sk-[a-zA-Z0-9]{32,}$/,
       description: 'OpenAI API key format: sk-...'
     },
+    'OPENROUTER_API_KEY': {
+      pattern: /^sk-or-v1-[a-f0-9]{64,}$/,
+      description: 'OpenAI API key format: sk-...'
+    },
     'HUGGINGFACE_TOKEN': {
       pattern: /^hf_[a-zA-Z0-9]{32,}$/,
       description: 'Hugging Face token format: hf_...'


### PR DESCRIPTION
Adding {openrouter](https://openrouter.ai/) API key as this platform is popular for using multiple API providers.

Openrouter API Key format (edited and deleted keys, so don't worry)
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
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

All keys start with `sk-or-v1-` and have 64 characters in base64 (0-9 and a-f)